### PR TITLE
CIと同等のcheckをlocalでも行えるような make targetを作成した

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: check-all lint test
+
+
+check-all: lint test
+
+lint:
+	pylint cmdblog_backend
+
+test:
+	python manage.py test

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@
 2. `git fetch upstream`でlocalのupstreamを更新する
 3. `git rebase upstream/main`で、最新のupstream/mainをlocalのmainブランチに取り込む
 4. `git checkout -b <わかりやすいブランチ名>` or `git switch -c <わかりやすいブランチ名>` で機能用ブランチを切る
-5. コードに修正を加え、必要ならばテストを付け、`git commit` `git push` する
-6. 本repositoryへのPRを作成し、reviewersを指定する。
-7. approveされた後、PR作成者(or 誰でもいい)がmergeボタンを押す
-8. PR画面からremoteの機能用ブランチを消す
-9. `git cehckout main` or `git switch main`でmainブランチに戻り、`git fetch --prune` `git fetch -D <当該ブランチ名>` で、機能用ブランチを削除する
+5. コードに修正を加え、必要ならばテストを付ける
+6. `make check-all` で問題がないことを確認し、`git commit` `git push` する
+7. 本repositoryへのPRを作成し、reviewersを指定する。
+8. approveされた後、PR作成者(or 誰でもいい)がmergeボタンを押す
+9. PR画面からremoteの機能用ブランチを消す
+10. `git cehckout main` or `git switch main`でmainブランチに戻り、`git fetch --prune` `git fetch -D <当該ブランチ名>` で、機能用ブランチを削除する


### PR DESCRIPTION
# 概要

CIで実施しているテストをlocalでまとめて実行できる、`make check-all` というmake targetを作成した。


# 動作確認の方法

`make check-all` が動作する

# チケット

https://yurichiki.atlassian.net/browse/CMDBLOG-32