### PR TITLE
基本はPR作成者がmergeする旨をREADMEに記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
 5. コードに修正を加え、必要ならばテストを付ける
 6. `make check-all` で問題がないことを確認し、`git commit` `git push` する
 7. 本repositoryへのPRを作成し、reviewersを指定する。
-8. approveされた後、PR作成者(or 誰でもいい)がmergeボタンを押す
+8. approveされた後、**PR作成者**がmergeボタンを押す。
+    - 例外
+        - PR作成者にmerge権限がない場合はPR作成者以外がmergeしてもよい。
+        - PR作成者にmergeをしてもらうことが困難で、かつそのPRのmergeが他のタスクのボトルネックになっている際は、PR作成者以外がmergeしてもよい
 9. PR画面からremoteの機能用ブランチを消す
 10. `git cehckout main` or `git switch main`でmainブランチに戻り、`git fetch --prune` `git fetch -D <当該ブランチ名>` で、機能用ブランチを削除する


### PR DESCRIPTION
# 概要
現在の記述では、approveされた後、誰がmergeするかがあいまいだった
PR作成者がmergeするか、approve者がmergeするか、誰でもいいのかという問題があるが、基本的にはPR作成者がmergeボタンを押すことに決めた。


## 参考
- https://qiita.com/numa08/items/8486b53daa5f159d710a
- https://github.com/sakura-editor/management-forum/issues/49

# 動作確認の方法

n/a

# チケット

n/a