### PR TITLE
OpenAPI Schema を生成できるようにした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 db.sqlite3
 __pycache__
+openapi-schema.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check-all lint test gen-schema
+.PHONY: check-all lint test openapi-schema.yaml
 
 
 check-all: lint test
@@ -9,5 +9,5 @@ lint:
 test:
 	python manage.py test
 
-gen-schema:
+openapi-schema.yaml:
 	python manage.py generateschema --file openapi-schema.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check-all lint test
+.PHONY: check-all lint test gen-schema
 
 
 check-all: lint test
@@ -8,3 +8,6 @@ lint:
 
 test:
 	python manage.py test
+
+gen-schema:
+	python manage.py generateschema --file openapi-schema.yaml

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,4 @@ test:
 
 openapi-schema.yaml:
 	python manage.py generateschema --file openapi-schema.yaml
+	sed -i "s/version: ''/version: '$(TAG)'/" openapi-schema.yaml

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,3 +2,5 @@ pylint-django==2.5.3
 pytest>=5.4
 pytest-django>=4.5
 pytest-mock>=3.7
+uritemplate >= 4.1.1
+pyyaml >= 6.0


### PR DESCRIPTION
# 概要

`make TAG=vx.y.z openapi-schema.yaml`でopenapi schema が生成できる。
schemaファイル自体は cmdblog/cmdblog-schema repositoryで管理するので、このrepositoryでは管理しない。

# 動作確認の方法

以下は生成したもの。確かに生成できた。
- https://gist.github.com/yuchiki/6750c0446616460179b25fd804ed6329

# チケット

https://yurichiki.atlassian.net/jira/software/projects/CMDBLOG/boards/1/backlog?selectedIssue=CMDBLOG-41
