### PR TITLE
Version apiのmock実装を作成

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,3 +5,6 @@ django-settings-module=cmdblog_backend.settings
 
 [DESIGN]
 max-parents=15
+
+[MESSAGES CONTROL]
+disable=fixme

--- a/cmdblog_backend/settings.py
+++ b/cmdblog_backend/settings.py
@@ -128,6 +128,6 @@ REST_FRAMEWORK = {
     # Use Django's standard `django.contrib.auth` permissions,
     # or allow read-only access for unauthenticated users.
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
+        'rest_framework.permissions.AllowAny'
     ]
 }

--- a/cmdblog_backend/tests.py
+++ b/cmdblog_backend/tests.py
@@ -2,6 +2,7 @@
 API test
 """
 from django.test import TestCase
+import json
 
 
 class RootTests(TestCase):
@@ -16,3 +17,20 @@ class RootTests(TestCase):
 
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)
+
+
+class VersionTests(TestCase):
+    """
+    /version のテスト
+    """
+
+    def test_version_returns_version(self):
+        """
+        /version が 200で、versionを返す
+        """
+
+        response = self.client.get('/version')
+        self.assertEqual(response.status_code, 200)
+
+        returned_json = json.loads(response.content)
+        self.assertEqual(returned_json['version'], "DUMMY_VERSION")

--- a/cmdblog_backend/tests.py
+++ b/cmdblog_backend/tests.py
@@ -1,8 +1,9 @@
 """docstring
 API test
 """
-from django.test import TestCase
+
 import json
+from django.test import TestCase
 
 
 class RootTests(TestCase):

--- a/cmdblog_backend/urls.py
+++ b/cmdblog_backend/urls.py
@@ -49,6 +49,7 @@ class UserViewSet(viewsets.ModelViewSet):
 router = routers.DefaultRouter()
 router.register(r'users', UserViewSet)
 
+# TODO: verison が、openapi-schemaに反映されるような書き方をする。
 urlpatterns = [
     path('', include(router.urls)),
     path('api-auth/', include('rest_framework.urls')),

--- a/cmdblog_backend/urls.py
+++ b/cmdblog_backend/urls.py
@@ -17,6 +17,8 @@ Including another URLconf
 from django.urls import include, path
 from django.contrib.auth import get_user_model
 from rest_framework import routers, serializers, viewsets
+from .views import version
+
 
 # Serializers define the API representation.
 
@@ -47,8 +49,8 @@ class UserViewSet(viewsets.ModelViewSet):
 router = routers.DefaultRouter()
 router.register(r'users', UserViewSet)
 
-
 urlpatterns = [
     path('', include(router.urls)),
-    path('api-auth/', include('rest_framework.urls'))
+    path('api-auth/', include('rest_framework.urls')),
+    path('version', version, name='version')
 ]

--- a/cmdblog_backend/views.py
+++ b/cmdblog_backend/views.py
@@ -1,3 +1,6 @@
+"""
+    views
+"""
 
 from rest_framework.decorators import api_view
 from rest_framework.response import Response

--- a/cmdblog_backend/views.py
+++ b/cmdblog_backend/views.py
@@ -5,4 +5,9 @@ from rest_framework.response import Response
 
 @api_view()
 def version(request):
+    """
+    version を返す
+    """
+
+    # TODO: 環境変数で、versionを埋め込めるようにする
     return Response({"version": "DUMMY_VERSION"})

--- a/cmdblog_backend/views.py
+++ b/cmdblog_backend/views.py
@@ -1,0 +1,8 @@
+
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+
+@api_view()
+def version(request):
+    return Response({"version": "DUMMY_VERSION"})


### PR DESCRIPTION
# 概要

/version API endpointを用意した。
現在は固定値を返すのみであり、のちのち実際のヴァージョンを取得できるようにしなければならない。
また、openapi-schemaに反映されていないので、それものちに修正する必要がある。

# 動作確認の方法

CIがpassする

# チケット
https://yurichiki.atlassian.net/browse/CMDBLOG-12